### PR TITLE
Fix missing brackets in export expression

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
 import XImage from './src/XImage';
 
 export default XImage;
-export Storage from './src/Storage';
+export { Storage } from './src/Storage';


### PR DESCRIPTION
Import 'react-native-ximage' will throw error without these brackets.
As of react-native@0.22.2